### PR TITLE
Make the library compatible with Symfony 3 and PHP 5.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,9 @@
         }
     ],
     "require" : {
-        "php" : "~5.4||~7.0",
+        "php" : "^5.4||~7.0",
         "behat/behat" : "~3.0",
-        "symfony/process" : "~2.3"
+        "symfony/process" : "~2.3||~3.0"
     },
     "require-dev": {
         "ciaranmcnulty/phpspec-typehintedmethods" : "~1.0",


### PR DESCRIPTION
I couldn't install this nice extension with a Symfony v3 Process component installed. I also couldn't install it on PHP 5.6, which is a bit strange, since ~5.4 would also match 5.6.11... Nevertheless, it works now. :)
